### PR TITLE
remove white space from under the page when collapsed

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,7 +4,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    height: 100vh;
+    height: min-content;
     width: 100vw;
     z-index: 1000 ;
     pointer-events: none;


### PR DESCRIPTION
min-content makes it so when overlay is collapsed it has 0 height and thus doesn't add white space under the page, it's important on touch screen devices because when you swipe to draw it instead scrolls the page up and down because of that white space.

I see that this overlay has a lot of different styles for different screen sizes, unsure how to test those but while expanded it looks the same with this change for me