### PR TITLE
Fix mobile layout of Edit Template

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -143,7 +143,6 @@
 
 .FileInput > input[type=file] {
     height: auto;
-    width: min-content;
 }
 
 .Overlay .icon path {

--- a/src/components/Overlay/Overlay.css
+++ b/src/components/Overlay/Overlay.css
@@ -10,6 +10,7 @@
     width: 100vw;
     bottom: 0;
     left: 0;
+    max-height: 70vh;
     border-radius: var(--radius-box);
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;


### PR DESCRIPTION
The layout for Edit Template is currently broken when viewed in a phones and small browser screen sizes, where the div size exceeds the viewport both horizontally and vertically. Because of that, you're unable to scroll up/down to save the template or hide the template manager. 

I fixed it with minimal changes and it seems to be in at least a usable state in small screen sizes for now.